### PR TITLE
Fix hardcoded path & support `-i` option

### DIFF
--- a/makepkg.conf.sample
+++ b/makepkg.conf.sample
@@ -3,7 +3,7 @@
 #
 
 # This is used in VITABUILD files
-PREFIX=/usr/local/vitasdk/arm-vita-eabi/
+PREFIX=$VITASDK/arm-vita-eabi/
 
 #########################################################################
 # SOURCE ACQUISITION

--- a/vita-makepkg
+++ b/vita-makepkg
@@ -207,7 +207,7 @@ missing_source_file() {
 
 run_pacman() {
 	if (( "$1" == "-U" )); then
-		vdpm ${PWD##*/}
+		vdpm "${*:2}"
 	else
 		echo "asked to run pacman?"
 		exit 1

--- a/vita-makepkg
+++ b/vita-makepkg
@@ -206,8 +206,12 @@ missing_source_file() {
 }
 
 run_pacman() {
-	echo "asked to run pacman?"
-	exit 1
+	if (( "$1" == "-U" )); then
+		vdpm ${PWD##*/}
+	else
+		echo "asked to run pacman?"
+		exit 1
+	fi
 }
 
 check_deps() {

--- a/vita-makepkg
+++ b/vita-makepkg
@@ -30,7 +30,7 @@
 #   awk, bsdtar (libarchive), bzip2, coreutils, fakeroot, file, find (findutils),
 #   gettext, gpg, grep, gzip, sed, tput (ncurses), xz
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "$(readlink -f ${BASH_SOURCE[0]})" )" && pwd )"
 LIBRARY="$DIR"/libmakepkg
 
 # gettext initialization

--- a/vita-makepkg
+++ b/vita-makepkg
@@ -707,7 +707,7 @@ create_package() {
 	# bsdtar's gzip compression always saves the time stamp, making one
 	# archive created using the same command line distinct from another.
 	# Disable bsdtar compression and use gzip -n for now.
-	cd_safe "usr/local/vitasdk/arm-vita-eabi"
+	cd_safe "./$VITASDK/arm-vita-eabi"
 	LANG=C bsdtar -hcf - * |
 	case "$PKGEXT" in
 		*tar.gz)  ${COMPRESSGZ[@]:-gzip -c -f -n} ;;


### PR DESCRIPTION
1. If someone installed sdk to another location, this script will break.
2. now can support `vita-makepkg -i` or `vita-makepkg -if`; install package after build. it related vitasdk/vdpm#5