### PR TITLE
Fix pkgver() function not working

### DIFF
--- a/vita-makepkg
+++ b/vita-makepkg
@@ -182,12 +182,12 @@ update_pkgver() {
 
 	if [[ -n $newpkgver && $newpkgver != "$pkgver" ]]; then
 		if [[ -f $BUILDFILE && -w $BUILDFILE ]]; then
-			if ! @SEDINPLACE@ "s:^pkgver=[^ ]*:pkgver=$newpkgver:" "$BUILDFILE"; then
+			if ! sed -i "s:^pkgver=[^ ]*:pkgver=$newpkgver:" "$BUILDFILE"; then
 				error "$(gettext "Failed to update %s from %s to %s")" \
 						"pkgver" "$pkgver" "$newpkgver"
 				exit 1
 			fi
-			@SEDINPLACE@ "s:^pkgrel=[^ ]*:pkgrel=1:" "$BUILDFILE"
+			sed -i "s:^pkgrel=[^ ]*:pkgrel=1:" "$BUILDFILE"
 			source_safe "$BUILDFILE"
 			local fullver=$(get_full_version)
 			msg "$(gettext "Updated version: %s")" "$pkgbase $fullver"


### PR DESCRIPTION
@SEDINPLACE@ was still there. Normally this would be replaced by the build system. With this you can use the pkgver() command to update versions of packages which are hosted on git without releases.