### PR TITLE
Make vita-makepkg not error out when a package is unavailable.

### DIFF
--- a/libmakepkg/source.sh
+++ b/libmakepkg/source.sh
@@ -36,7 +36,8 @@ done
 download_sources() {
 	local netfile all_sources
 	local get_source_fn=get_all_sources_for_arch get_vcs=1
-
+	local retval
+	
 	msg "$(gettext "Retrieving sources...")"
 
 	while true; do
@@ -57,31 +58,39 @@ download_sources() {
 	"$get_source_fn" 'all_sources'
 	for netfile in "${all_sources[@]}"; do
 		pushd "$SRCDEST" &>/dev/null
-
+		
 		local proto=$(get_protocol "$netfile")
 		case "$proto" in
 			local)
 				download_local "$netfile"
+				retval=$?
 				;;
 			bzr*)
 				(( get_vcs )) && download_bzr "$netfile"
+				retval=$?
 				;;
 			git*)
 				(( get_vcs )) && download_git "$netfile"
+				retval=$?
 				;;
 			hg*)
 				(( get_vcs )) && download_hg "$netfile"
+				retval=$?
 				;;
 			svn*)
 				(( get_vcs )) && download_svn "$netfile"
+				retval=$?
 				;;
 			*)
 				download_file "$netfile"
+				retval=$?
 				;;
 		esac
 
 		popd &>/dev/null
 	done
+	
+	return $retval
 }
 
 extract_sources() {

--- a/libmakepkg/source/bzr.sh
+++ b/libmakepkg/source/bzr.sh
@@ -92,9 +92,8 @@ extract_bzr() {
 	if [[ -d "${dir##*/}" ]]; then
 		cd_safe "${dir##*/}"
 		if ! (bzr pull "$dir" -q --overwrite -r "$rev" && bzr clean-tree -q --detritus --force); then
-			error "$(gettext "Failure while updating working copy of %s %s repo")" "${repo}" "bzr"
-			plain "$(gettext "Aborting...")"
-			exit 1
+			warning "$(gettext "Failure while updating working copy of %s %s repo")" "${repo}" "bzr"
+			return 0
 		fi
 	elif ! bzr checkout "$dir" -r "$rev"; then
 		error "$(gettext "Failure while creating working copy of %s %s repo")" "${repo}" "bzr"
@@ -103,4 +102,6 @@ extract_bzr() {
 	fi
 
 	popd &>/dev/null
+	
+	return 1
 }

--- a/libmakepkg/source/file.sh
+++ b/libmakepkg/source/file.sh
@@ -34,7 +34,7 @@ download_file() {
 	local filepath=$(get_filepath "$netfile")
 	if [[ -n "$filepath" ]]; then
 		msg2 "$(gettext "Found %s")" "${filepath##*/}"
-		return
+		return 1
 	fi
 
 	local proto=$(get_protocol "$netfile")
@@ -71,15 +71,16 @@ download_file() {
 
 	if ! command -- "${cmdline[@]}" >&2; then
 		[[ ! -s $dlfile ]] && rm -f -- "$dlfile"
-		error "$(gettext "Failure while downloading %s")" "$url"
-		plain "$(gettext "Aborting...")"
-		exit 1
+		warning "$(gettext "Failure while downloading %s")" "$url"
+		return 0
 	fi
 
 	# rename the temporary download file to the final destination
 	if [[ $dlfile != "$filename" ]]; then
 		mv -f "$SRCDEST/$dlfile" "$SRCDEST/$filename"
 	fi
+	
+	return 1
 }
 
 extract_file() {

--- a/libmakepkg/source/git.sh
+++ b/libmakepkg/source/git.sh
@@ -44,7 +44,7 @@ download_git() {
 		msg2 "$(gettext "Cloning %s %s repo...")" "${repo}" "git"
 		if ! git clone --mirror "$url" "$dir"; then
 			warning "$(gettext "Failure while downloading %s %s repo")" "${repo}" "git"
-			return 0
+			return 1
 		fi
 	elif (( ! HOLDVER )); then
 		cd_safe "$dir"
@@ -61,7 +61,7 @@ download_git() {
 		fi
 	fi
 	
-	return 1
+	return 0
 }
 
 extract_git() {

--- a/libmakepkg/source/git.sh
+++ b/libmakepkg/source/git.sh
@@ -43,9 +43,8 @@ download_git() {
 	if [[ ! -d "$dir" ]] || dir_is_empty "$dir" ; then
 		msg2 "$(gettext "Cloning %s %s repo...")" "${repo}" "git"
 		if ! git clone --mirror "$url" "$dir"; then
-			error "$(gettext "Failure while downloading %s %s repo")" "${repo}" "git"
-			plain "$(gettext "Aborting...")"
-			exit 1
+			warning "$(gettext "Failure while downloading %s %s repo")" "${repo}" "git"
+			return 0
 		fi
 	elif (( ! HOLDVER )); then
 		cd_safe "$dir"
@@ -61,6 +60,8 @@ download_git() {
 			warning "$(gettext "Failure while updating %s %s repo")" "${repo}" "git"
 		fi
 	fi
+	
+	return 1
 }
 
 extract_git() {

--- a/libmakepkg/source/hg.sh
+++ b/libmakepkg/source/hg.sh
@@ -43,9 +43,8 @@ download_hg() {
 	if [[ ! -d "$dir" ]] || dir_is_empty "$dir" ; then
 		msg2 "$(gettext "Cloning %s %s repo...")" "${repo}" "hg"
 		if ! hg clone -U "$url" "$dir"; then
-			error "$(gettext "Failure while downloading %s %s repo")" "${repo}" "hg"
-			plain "$(gettext "Aborting...")"
-			exit 1
+			warning "$(gettext "Failure while downloading %s %s repo")" "${repo}" "hg"
+			return 0
 		fi
 	elif (( ! HOLDVER )); then
 		msg2 "$(gettext "Updating %s %s repo...")" "${repo}" "hg"
@@ -55,6 +54,8 @@ download_hg() {
 			warning "$(gettext "Failure while updating %s %s repo")" "${repo}" "hg"
 		fi
 	fi
+	
+	return 1
 }
 
 extract_hg() {

--- a/libmakepkg/source/local.sh
+++ b/libmakepkg/source/local.sh
@@ -39,4 +39,6 @@ download_local() {
 		error "$(gettext "%s was not found in the build directory and is not a URL.")" "$filename"
 		exit 1 # $E_MISSING_FILE
 	fi
+	
+	return 1
 }

--- a/libmakepkg/source/local.sh
+++ b/libmakepkg/source/local.sh
@@ -40,5 +40,5 @@ download_local() {
 		exit 1 # $E_MISSING_FILE
 	fi
 	
-	return 1
+	return 0
 }

--- a/libmakepkg/source/svn.sh
+++ b/libmakepkg/source/svn.sh
@@ -65,7 +65,7 @@ download_svn() {
 		mkdir -p "$dir/.makepkg"
 		if ! svn checkout -r ${ref} --config-dir "$dir/.makepkg" "$url" "$dir"; then
 			warning "$(gettext "Failure while downloading %s %s repo")" "${repo}" "svn"
-			return 0
+			return 1
 		fi
 	elif (( ! HOLDVER )); then
 		msg2 "$(gettext "Updating %s %s repo...")" "${repo}" "svn"
@@ -76,7 +76,7 @@ download_svn() {
 		fi
 	fi
 	
-	return 1
+	return 0
 }
 
 extract_svn() {

--- a/libmakepkg/source/svn.sh
+++ b/libmakepkg/source/svn.sh
@@ -64,9 +64,8 @@ download_svn() {
 		msg2 "$(gettext "Cloning %s %s repo...")" "${repo}" "svn"
 		mkdir -p "$dir/.makepkg"
 		if ! svn checkout -r ${ref} --config-dir "$dir/.makepkg" "$url" "$dir"; then
-			error "$(gettext "Failure while downloading %s %s repo")" "${repo}" "svn"
-			plain "$(gettext "Aborting...")"
-			exit 1
+			warning "$(gettext "Failure while downloading %s %s repo")" "${repo}" "svn"
+			return 0
 		fi
 	elif (( ! HOLDVER )); then
 		msg2 "$(gettext "Updating %s %s repo...")" "${repo}" "svn"
@@ -76,6 +75,8 @@ download_svn() {
 			warning "$(gettext "Failure while updating %s %s repo")" "${repo}" "svn"
 		fi
 	fi
+	
+	return 1
 }
 
 extract_svn() {

--- a/vita-makepkg
+++ b/vita-makepkg
@@ -1588,7 +1588,10 @@ if (( !REPKG )); then
 	if (( NOEXTRACT && ! VERIFYSOURCE )); then
 		warning "$(gettext "Using existing %s tree")" "\$srcdir/"
 	else
-		download_sources
+		if (( ! download_sources )); then
+			msg "$(gettext "Cannot retrieve %s, skipping...")" "$pkgbase"
+			exit 0
+		fi
 		check_source_integrity
 		(( VERIFYSOURCE )) && exit 0 # $E_OK
 

--- a/vita-makepkg
+++ b/vita-makepkg
@@ -1588,7 +1588,7 @@ if (( !REPKG )); then
 	if (( NOEXTRACT && ! VERIFYSOURCE )); then
 		warning "$(gettext "Using existing %s tree")" "\$srcdir/"
 	else
-		if (( ! download_sources )); then
+		if ( download_sources ); then
 			msg "$(gettext "Cannot retrieve %s, skipping...")" "$pkgbase"
 			exit 0
 		fi


### PR DESCRIPTION
Not tested since i don't have a proper Linux setup and probably not the best way to handle this.
The scope of this is to make vita-makepkg not error out when a package is temporarily unavaialable so that travis won't fail a build for a single package.

The idea is to fix cases in which stuffs like these happen: https://api.travis-ci.org/v3/job/698182139/log.txt