### PR TITLE
Do not require binutils to be installed to build packages

### DIFF
--- a/vita-makepkg
+++ b/vita-makepkg
@@ -1025,8 +1025,8 @@ check_software() {
 
 	# strip - strip symbols from binaries/libraries
 	if check_option "strip" "y"; then
-		if ! type -p strip >/dev/null; then
-			error "$(gettext "Cannot find the %s binary required for object file stripping.")" "strip"
+		if ! type -p arm-vita-eabi-strip >/dev/null; then
+			error "$(gettext "Cannot find the %s binary required for object file stripping.")" "arm-vita-eabi-strip"
 			ret=1
 		fi
 	fi


### PR DESCRIPTION
Currently binutils is required to run vita-makepkg, even though it does not use any of the tools in it. The reason is that it checks if a binary called strip is found in the user's path. With this change, it will look for the strip binary it actually uses, no longer requiring binutils to be installed.

If this is not seen as spam, could a label called hacktoberfest be added to this PR? I'm trying to earn a t-shirt :D