### PR TITLE
Fix cd_safe when building packages

### DIFF
--- a/vita-makepkg
+++ b/vita-makepkg
@@ -712,7 +712,7 @@ create_package() {
 	# bsdtar's gzip compression always saves the time stamp, making one
 	# archive created using the same command line distinct from another.
 	# Disable bsdtar compression and use gzip -n for now.
-	cd_safe "./$VITASDK/arm-vita-eabi"
+	cd_safe "$VITASDK/arm-vita-eabi"
 	LANG=C bsdtar -hcf - * |
 	case "$PKGEXT" in
 		*tar.gz)  ${COMPRESSGZ[@]:-gzip -c -f -n} ;;


### PR DESCRIPTION
Otherwise, when building packages, you get

```
$VITASDK/bin/libmakepkg/util/util.sh: line 80: cd: ./$VITASDK/arm-vita-eabi: No such file or directory
```

VITASDK is meant to be a full path and making it relative in this script breaks building.